### PR TITLE
Add theme selection options

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "npm run lint:frontend ; npm run lint:types ; npm run lint:backend",
-		"lint:frontend": "eslint . --fix",
+                "lint:frontend": "eslint -c .eslintrc.cjs . --fix",
 		"lint:types": "npm run check",
 		"lint:backend": "pylint backend/",
 		"format": "prettier --plugin-search-dir --write \"**/*.{js,ts,svelte,css,md,html,json}\"",

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -4,7 +4,8 @@
 	import { getLanguages, changeLanguage } from '$lib/i18n';
 	const dispatch = createEventDispatcher();
 
-	import { models, settings, theme, user } from '$lib/stores';
+        import { models, settings, theme, user } from '$lib/stores';
+        import { themes as availableThemes, changeTheme } from '$lib/utils/theme';
 
 	const i18n = getContext('i18n');
 
@@ -14,7 +15,7 @@
 	export let getModels: Function;
 
 	// General
-	let themes = ['dark', 'light', 'oled-dark'];
+        let themes = availableThemes;
 	let selectedTheme = 'system';
 
 	let languages: Awaited<ReturnType<typeof getLanguages>> = [];
@@ -116,75 +117,11 @@
 		params.stop = $settings?.params?.stop ? ($settings?.params?.stop ?? []).join(',') : null;
 	});
 
-	const applyTheme = (_theme: string) => {
-		let themeToApply = _theme === 'oled-dark' ? 'dark' : _theme;
 
-		if (_theme === 'system') {
-			themeToApply = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-		}
-
-		if (themeToApply === 'dark' && !_theme.includes('oled')) {
-			document.documentElement.style.setProperty('--color-gray-800', '#333');
-			document.documentElement.style.setProperty('--color-gray-850', '#262626');
-			document.documentElement.style.setProperty('--color-gray-900', '#171717');
-			document.documentElement.style.setProperty('--color-gray-950', '#0d0d0d');
-		}
-
-		themes
-			.filter((e) => e !== themeToApply)
-			.forEach((e) => {
-				e.split(' ').forEach((e) => {
-					document.documentElement.classList.remove(e);
-				});
-			});
-
-		themeToApply.split(' ').forEach((e) => {
-			document.documentElement.classList.add(e);
-		});
-
-		const metaThemeColor = document.querySelector('meta[name="theme-color"]');
-		if (metaThemeColor) {
-			if (_theme.includes('system')) {
-				const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
-					? 'dark'
-					: 'light';
-				console.log('Setting system meta theme color: ' + systemTheme);
-				metaThemeColor.setAttribute('content', systemTheme === 'light' ? '#ffffff' : '#171717');
-			} else {
-				console.log('Setting meta theme color: ' + _theme);
-				metaThemeColor.setAttribute(
-					'content',
-					_theme === 'dark'
-						? '#171717'
-						: _theme === 'oled-dark'
-							? '#000000'
-							: _theme === 'her'
-								? '#983724'
-								: '#ffffff'
-				);
-			}
-		}
-
-		if (typeof window !== 'undefined' && window.applyTheme) {
-			window.applyTheme();
-		}
-
-		if (_theme.includes('oled')) {
-			document.documentElement.style.setProperty('--color-gray-800', '#101010');
-			document.documentElement.style.setProperty('--color-gray-850', '#050505');
-			document.documentElement.style.setProperty('--color-gray-900', '#000000');
-			document.documentElement.style.setProperty('--color-gray-950', '#000000');
-			document.documentElement.classList.add('dark');
-		}
-
-		console.log(_theme);
-	};
-
-	const themeChangeHandler = (_theme: string) => {
-		theme.set(_theme);
-		localStorage.setItem('theme', _theme);
-		applyTheme(_theme);
-	};
+        const themeChangeHandler = (_theme: string) => {
+                theme.set(_theme);
+                changeTheme(_theme);
+        };
 </script>
 
 <div class="flex flex-col h-full justify-between text-sm">

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -5,14 +5,15 @@
 	import { flyAndScale } from '$lib/utils/transitions';
 	import { goto } from '$app/navigation';
 	import ArchiveBox from '$lib/components/icons/ArchiveBox.svelte';
-	import { showSettings, activeUserIds, USAGE_POOL, mobile, showSidebar, user } from '$lib/stores';
-	import { fade, slide } from 'svelte/transition';
-	import Tooltip from '$lib/components/common/Tooltip.svelte';
-	import { userSignOut } from '$lib/apis/auths';
-	import QuestionMarkCircle from '$lib/components/icons/QuestionMarkCircle.svelte';
-	import Map from '$lib/components/icons/Map.svelte';
-	import Keyboard from '$lib/components/icons/Keyboard.svelte';
-	import ShortcutsModal from '$lib/components/chat/ShortcutsModal.svelte';
+import { showSettings, activeUserIds, USAGE_POOL, mobile, showSidebar, user, theme } from '$lib/stores';
+import { fade, slide } from 'svelte/transition';
+import Tooltip from '$lib/components/common/Tooltip.svelte';
+import { userSignOut } from '$lib/apis/auths';
+import QuestionMarkCircle from '$lib/components/icons/QuestionMarkCircle.svelte';
+import Map from '$lib/components/icons/Map.svelte';
+import Keyboard from '$lib/components/icons/Keyboard.svelte';
+import ShortcutsModal from '$lib/components/chat/ShortcutsModal.svelte';
+import { themes as availableThemes, changeTheme } from '$lib/utils/theme';
 
 	const i18n = getContext('i18n');
 
@@ -21,7 +22,18 @@
 	export let help = false;
 	export let className = 'max-w-[240px]';
 
-	let showShortcuts = false;
+let showShortcuts = false;
+
+let selectedTheme = 'system';
+
+onMount(() => {
+        selectedTheme = localStorage.theme ?? 'system';
+});
+
+const themeChangeHandler = () => {
+        theme.set(selectedTheme);
+        changeTheme(selectedTheme);
+};
 
 	const dispatch = createEventDispatcher();
 </script>
@@ -96,9 +108,24 @@
 					<ArchiveBox className="size-5" strokeWidth="1.5" />
 				</div>
 				<div class=" self-center truncate">{$i18n.t('Archived Chats')}</div>
-			</button>
+                        </button>
 
-			{#if role === 'admin'}
+                        <div class="flex justify-between items-center py-1.5 px-3">
+                                <div class="text-xs font-medium">{$i18n.t('Theme')}</div>
+                                <select
+                                        class="dark:bg-gray-900 w-fit pr-8 rounded-sm py-1 px-2 text-xs bg-transparent outline-hidden text-right"
+                                        bind:value={selectedTheme}
+                                        on:change={themeChangeHandler}
+                                >
+                                        <option value="system">⚙️ {$i18n.t('System')}</option>
+                                        <option value="dark">🌑 {$i18n.t('Dark')}</option>
+                                        <option value="oled-dark">🌃 {$i18n.t('OLED Dark')}</option>
+                                        <option value="light">☀️ {$i18n.t('Light')}</option>
+                                        <option value="her">🌷 Her</option>
+                                </select>
+                        </div>
+
+                        {#if role === 'admin'}
 				<a
 					class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition"
 					href="/playground"

--- a/src/lib/utils/theme.ts
+++ b/src/lib/utils/theme.ts
@@ -1,0 +1,64 @@
+export const themes = ['dark', 'light', 'oled-dark', 'her'];
+
+export const applyTheme = (_theme: string) => {
+    let themeToApply = _theme === 'oled-dark' ? 'dark' : _theme;
+
+    if (_theme === 'system') {
+        themeToApply = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    if (themeToApply === 'dark' && !_theme.includes('oled')) {
+        document.documentElement.style.setProperty('--color-gray-800', '#333');
+        document.documentElement.style.setProperty('--color-gray-850', '#262626');
+        document.documentElement.style.setProperty('--color-gray-900', '#171717');
+        document.documentElement.style.setProperty('--color-gray-950', '#0d0d0d');
+    }
+
+    themes
+        .filter((e) => e !== themeToApply)
+        .forEach((e) => {
+            e.split(' ').forEach((cls) => {
+                document.documentElement.classList.remove(cls);
+            });
+        });
+
+    themeToApply.split(' ').forEach((cls) => {
+        document.documentElement.classList.add(cls);
+    });
+
+    const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+    if (metaThemeColor) {
+        if (_theme.includes('system')) {
+            const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            metaThemeColor.setAttribute('content', systemTheme === 'light' ? '#ffffff' : '#171717');
+        } else {
+            metaThemeColor.setAttribute(
+                'content',
+                _theme === 'dark'
+                    ? '#171717'
+                    : _theme === 'oled-dark'
+                        ? '#000000'
+                        : _theme === 'her'
+                            ? '#983724'
+                            : '#ffffff'
+            );
+        }
+    }
+
+    if (typeof window !== 'undefined' && (window as any).applyTheme) {
+        (window as any).applyTheme();
+    }
+
+    if (_theme.includes('oled')) {
+        document.documentElement.style.setProperty('--color-gray-800', '#101010');
+        document.documentElement.style.setProperty('--color-gray-850', '#050505');
+        document.documentElement.style.setProperty('--color-gray-900', '#000000');
+        document.documentElement.style.setProperty('--color-gray-950', '#000000');
+        document.documentElement.classList.add('dark');
+    }
+};
+
+export const changeTheme = (value: string) => {
+    localStorage.setItem('theme', value);
+    applyTheme(value);
+};


### PR DESCRIPTION
## Summary
- specify ESLint config path for `npm run lint`

## Testing
- `npm run lint` *(fails: A config object is using the "root" key - ESLint v9 incompatibility)*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae6d4b740832ebf208705cc1b4190