### PR TITLE
Add rose pine themes

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -54,11 +54,19 @@
 				} else if (localStorage.theme === 'light') {
 					document.documentElement.classList.add('light');
 					metaThemeColorTag.setAttribute('content', '#ffffff');
-				} else if (localStorage.theme === 'her') {
-					document.documentElement.classList.add('dark');
-					document.documentElement.classList.add('her');
-					metaThemeColorTag.setAttribute('content', '#983724');
-				} else {
+                                } else if (localStorage.theme === 'her') {
+                                        document.documentElement.classList.add('dark');
+                                        document.documentElement.classList.add('her');
+                                        metaThemeColorTag.setAttribute('content', '#983724');
+                                } else if (localStorage.theme === 'rose-pine dark') {
+                                        document.documentElement.classList.add('rose-pine');
+                                        document.documentElement.classList.add('dark');
+                                        metaThemeColorTag.setAttribute('content', '#191724');
+                                } else if (localStorage.theme === 'rose-pine-dawn light') {
+                                        document.documentElement.classList.add('rose-pine-dawn');
+                                        document.documentElement.classList.add('light');
+                                        metaThemeColorTag.setAttribute('content', '#fffaf3');
+                                } else {
 					document.documentElement.classList.add('dark');
 					metaThemeColorTag.setAttribute('content', '#171717');
 				}

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -14,7 +14,7 @@
 	export let getModels: Function;
 
 	// General
-	let themes = ['dark', 'light', 'oled-dark'];
+       let themes = ['dark', 'light', 'oled-dark', 'rose-pine dark', 'rose-pine-dawn light'];
 	let selectedTheme = 'system';
 
 	let languages: Awaited<ReturnType<typeof getLanguages>> = [];
@@ -152,16 +152,20 @@
 				metaThemeColor.setAttribute('content', systemTheme === 'light' ? '#ffffff' : '#171717');
 			} else {
 				console.log('Setting meta theme color: ' + _theme);
-				metaThemeColor.setAttribute(
-					'content',
-					_theme === 'dark'
-						? '#171717'
-						: _theme === 'oled-dark'
-							? '#000000'
-							: _theme === 'her'
-								? '#983724'
-								: '#ffffff'
-				);
+                                       metaThemeColor.setAttribute(
+                                               'content',
+                                               _theme === 'dark'
+                                                       ? '#171717'
+                                                       : _theme === 'oled-dark'
+                                                               ? '#000000'
+                                                               : _theme === 'her'
+                                                                       ? '#983724'
+                                                                       : _theme === 'rose-pine dark'
+                                                                               ? '#191724'
+                                                                               : _theme === 'rose-pine-dawn light'
+                                                                                       ? '#fffaf3'
+                                                                                       : '#ffffff'
+                                       );
 			}
 		}
 
@@ -205,9 +209,9 @@
 						<option value="dark">🌑 {$i18n.t('Dark')}</option>
 						<option value="oled-dark">🌃 {$i18n.t('OLED Dark')}</option>
 						<option value="light">☀️ {$i18n.t('Light')}</option>
-						<option value="her">🌷 Her</option>
-						<!-- <option value="rose-pine dark">🪻 {$i18n.t('Rosé Pine')}</option>
-						<option value="rose-pine-dawn light">🌷 {$i18n.t('Rosé Pine Dawn')}</option> -->
+                                               <option value="her">🌷 Her</option>
+                                               <option value="rose-pine dark">🪻 {$i18n.t('Rosé Pine')}</option>
+                                               <option value="rose-pine-dawn light">🌷 {$i18n.t('Rosé Pine Dawn')}</option>
 					</select>
 				</div>
 			</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -659,10 +659,8 @@
 	<title>{$WEBUI_NAME}</title>
 	<link crossorigin="anonymous" rel="icon" href="{WEBUI_BASE_URL}/static/favicon.png" />
 
-	<!-- rosepine themes have been disabled as it's not up to date with our latest version. -->
-	<!-- feel free to make a PR to fix if anyone wants to see it return -->
-	<!-- <link rel="stylesheet" type="text/css" href="/themes/rosepine.css" />
-	<link rel="stylesheet" type="text/css" href="/themes/rosepine-dawn.css" /> -->
+       <link rel="stylesheet" type="text/css" href="/themes/rosepine.css" />
+       <link rel="stylesheet" type="text/css" href="/themes/rosepine-dawn.css" />
 </svelte:head>
 
 {#if loaded}


### PR DESCRIPTION
## Summary
- add Rosé Pine and Rosé Pine Dawn as selectable themes
- load the Rosé Pine CSS theme files
- set theme colors for the new themes

## Testing
- `npm run lint:frontend` *(fails: ESLint couldn't find config)*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af2aa09fc832e95edcc483254d2c7